### PR TITLE
Document repository-wide planning revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,6 @@
 
 Dieses Projekt skizziert das House-Layer-Modell und hält aktuell nur Platzhalter bereit.
 Der Basement-Layer beherbergt das `toolbox/`-Mono-Repo-Gerüst mit Katalogen, Projekten und dem geplanten Compose-Stack (Codex CLI + Ollama + Shared Volume). Für lokale Sessions steht `basement/toolbox/bin/gcodex` als Wrapper bereit.
+Die tagesaktuelle Gesamtübersicht findest du in [docs/revision-2025-09-28.md](docs/revision-2025-09-28.md).
 Weitere Details, Rollenbeschreibungen und das Diagramm finden sich in [docs/architecture.md](docs/architecture.md).
 Do not einspielen produktive Services oder Automationen, solange die Scaffold-Phase läuft.

--- a/basement/README.md
+++ b/basement/README.md
@@ -1,4 +1,6 @@
 Das Basement hält nackte Komponenten-Stubs und das Toolbox-Mono-Repo, die auf vollständige Konfiguration warten.
 Hier verankern wir Dienste und Entwicklungsstrukturen, bevor sie in höhere Ebenen gefördert werden.
 Projektabhängige Inventare (z.B. Homebrew-Listen) befinden sich unter `toolbox/inventories/`.
+Aktueller Überblick: siehe ../docs/revision-2025-09-28.md.
+
 Do not einchecken produktive Images, umfangreiche Abhängigkeiten oder Laufzeitdaten.

--- a/basement/toolbox/projects/toolbox/README.md
+++ b/basement/toolbox/projects/toolbox/README.md
@@ -42,8 +42,6 @@ services:
     working_dir: /workspace
 ```
 _Do not als echte Compose-Datei verwenden, solange der Build-/Release-Prozess nicht freigegeben ist._
-```
-_Do not als echte Compose-Datei verwenden, solange der Build-/Release-Prozess nicht freigegeben ist._
 
 ### CLI-Alias `gcodex`
 - Host-Skript: `basement/toolbox/bin/gcodex`
@@ -60,14 +58,16 @@ _Do not als echte Compose-Datei verwenden, solange der Build-/Release-Prozess ni
 - Umgang mit Credentials/API-Keys: wahrscheinlich `.env.local` auf Host-Seite + Weitergabe über Compose.
 - Logging-Strategie: Rotierung, Ablage im Shared Volume oder späterer Export.
 - MCP-Gateway-Spezifikation: Schnittstellen, erforderliche Tools, Sicherheitsmodell.
+- Wardrobe-Integration: Definition der Overlays, die sowohl macOS- als auch Windows/NVIDIA-Hosts ohne erneutes Provisioning nutzbar machen (z. B. GPU-spezifische Treiber-Pfade, Volume-Layout, persistente Shared Workspace-Struktur).
 
 ## Pending Tasks
 1. Basisimage für `codex-cli` finalisieren, Dockerfile-Konzept in `containers/codex-cli/` vorbereiten (Sicherheitsreview ausstehend).
 2. Compose-Skelett in eine Draft-Datei (`docker-compose.draft.yml`) übertragen und intern reviewen.
 3. Modell-Download-Strategie festhalten (`ollama pull <modell>` auf dem Host; `gpt-oss:20b` liegt bereits im Cache).
-4. Benutzerfreundlichen Einstieg weiter verfeinern (z. B. `gcodex`-Wrapper in höhere Layer promoten, Logging/Tracing ergänzen).
-5. Sicherheits- und Isolationsanforderungen (Mounts, Ports, Netzwerk) prüfen und dokumentieren.
-6. MCP-Gateway als Anschlussmodul beschreiben (Abhängigkeiten, Ports, Schnittstellen) – erst nach Fertigstellung des Minimal-Stacks.
+ 4. Benutzerfreundlichen Einstieg weiter verfeinern (z. B. `gcodex`-Wrapper in höhere Layer promoten, Logging/Tracing ergänzen).
+ 5. Sicherheits- und Isolationsanforderungen (Mounts, Ports, Netzwerk) prüfen und dokumentieren.
+ 6. Wardrobe-Overlays für Multi-Host-Einsatz beschreiben (Mac ↔ Windows mit NVIDIA-GPU) und sicherstellen, dass der Shared Workspace konsistent bleibt.
+ 7. MCP-Gateway als Anschlussmodul beschreiben (Abhängigkeiten, Ports, Schnittstellen) – erst nach Fertigstellung des Minimal-Stacks.
 
 ## Testschritte (Draft)
 - `docker compose -f basement/toolbox/docker-compose.draft.yml build codex-cli`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,8 @@
 # House Architecture Scaffold
 
 Die House-Metapher strukturiert unser Repository in klar getrennte Ebenen, damit jede Schicht eine definierte Verantwortung trägt und Übergänge nachvollziehbar bleiben.
+Die tagesaktuelle Zusammenfassung steht in [revision-2025-09-28.md](revision-2025-09-28.md) und ergänzt die hier beschriebene Architektur um konkrete Aufgaben.
+
 
 ## Layer Roles
 - **Fundament**: Verankert Basis-Setups, gemeinsame Netzwerke und Host-Anforderungen, bevor Services entstehen (nur Host-OS + Docker + Git).
@@ -8,6 +10,12 @@ Die House-Metapher strukturiert unser Repository in klar getrennte Ebenen, damit
 - **Wardrobe**: Stellt Überlagerungen, Verpackungen und Wrapper bereit (z. B. `basement/toolbox/bin/gcodex` für Codex-Chats) und bereitet Basement-Dienste für Tests vor.
 - **Entrance**: Dient als Frontdoor für frühe Nutzerinteraktionen, Canaries und Telemetrieexperimente.
 - **Stable**: Enthält freigegebene Produktions-Deployments sowie Monitoring- und Observability-Pfade.
+
+### Abgleich mit aktuellen Planungsannahmen
+- **Fundament** bleibt auf den Docker-Fokus reduziert: solange der Host zuverlässig Docker Desktop (bzw. passende Engine-Versionen auf anderen Plattformen) bereitstellt, kann jede weitere Schicht darauf aufbauen.
+- **Basement** priorisiert eine möglichst hostnahe Ausführung der LLM-Läufe. Ollama bleibt daher auf dem Host installiert, während der Codex-CLI-Container sich nur als dünner Client verhält und per Shared Workspace (`./shared:/workspace`) Dateien austauscht.
+- **Wardrobe** fungiert als „Suit Switcher“ zwischen unterschiedlichen Hosts. Overlays sollen sicherstellen, dass Sessions auf einem Windows/NVIDIA-System genauso starten wie auf dem macOS-Host, ohne Datenverluste oder manuelle Re-Konfiguration.
+- **Entrance** und **Stable** behalten ihren Planungsstatus; spätere Dokumentationen verlinken auf spezifische Canary-/Telemetry- bzw. Produktionspfade, sobald die Wardrobe-Overlays gefestigt sind.
 
 ## Mermaid Overview
 ```mermaid

--- a/docs/revision-2025-09-28.md
+++ b/docs/revision-2025-09-28.md
@@ -1,0 +1,52 @@
+# Repository Revision – 2025-09-28
+
+Diese Revision fasst den aktuellen Planungsstand aller House-Layer zusammen und integriert die heutigen Eingaben. Sie dient als Ausgangsbasis für die Arbeiten am Folgetag.
+
+## Eingang (heutiger Kontext)
+- **Fundament** bleibt dockerzentriert: Host stellt Docker Desktop/Engine bereit, zusätzliche Services laufen nur bei Bedarf. Ollama verbleibt hostseitig für maximale Performance.
+- **Basement** fokussiert auf hostnahe LLM-Läufe: Der Codex-CLI-Container agiert als dünner Client gegen `OLLAMA_HOST=http://host.docker.internal:11434` und nutzt ein Shared Volume (`./shared:/workspace`).
+- **Wardrobe** fungiert als plattformübergreifender „Suit Switcher“: Overlays sollen identische Workflows auf Windows/NVIDIA und macOS ermöglichen, ohne Datenverlust oder erneutes Provisioning.
+- **Toolbox** bildet den Dreh- und Angelpunkt für Projekte, Kataloge und Scripts; `gcodex` bleibt der primäre Einstieg in codex-gestützte Sessions.
+
+## Layer Snapshot
+### Fundament
+- Host-Baselines nachgeführt in [`fundament/README.md`](../fundament/README.md) und [`fundament/versions.yaml`](../fundament/versions.yaml).
+- Promotion- und Prüfpfade vorbereitet in [`fundament/STATE_VERIFICATION.md`](../fundament/STATE_VERIFICATION.md).
+- Nächste Schritte: Docker- und Git-Versionen bei Änderungen spiegeln, Host-Ollama-Status dokumentieren, geplante Netzwerk-/Volume-Vorlagen ergänzen.
+
+### Basement
+- Enthält Stubs für `g-ollama`, `g-openwebui` sowie das `toolbox/`-Monorepo.
+- Compose-Draft und Codex-Container-Dockerfile bleiben Entwürfe; produktive Images werden ausdrücklich vermieden.
+- Nächste Schritte: Codex-Image-Härtung reviewen, MCP-Gateway-Spezifikation ausarbeiten, Wardrobe-Anforderungen in den Compose-Draft rückspiegeln.
+
+### Wardrobe
+- Overlay-Strukturen (`configs/`, `overlays/`, `wrappers/`) dienen als Platzhalter für CPU/GPU/CI-Profile.
+- Fokus: Abläufe zwischen macOS-Host und Windows/NVIDIA-Host angleichen, `gcodex`-Wrapper als Referenz halten.
+- Nächste Schritte: Konkrete Overlay-Matrizen erstellen (z. B. GPU-Treiberpfade, Volume-Mapping), Automatisierungspfade skizzieren, Synchronisation mit Basement-Compose herstellen.
+
+### Entrance
+- Sandbox für Canaries & Telemetrie (siehe [`entrance/README.md`](../entrance/README.md)).
+- Aufgaben: Datenflussdefinitionen, Canary-Playbooks und Metriksammlung vorbereiten, sobald Wardrobe-Overlays getestet sind.
+
+### Stable
+- Produktionsskelett mit Host-/Monitoring-Platzhaltern (siehe [`stable/`](../stable/)).
+- Aufgaben: Promotion-Gates aus Fundament übernehmen, Observability-Roadmap planen, erst nach erfolgreichem Entrance/Canary-Einsatz füllen.
+
+## Toolbox Spotlight
+- Projektübersicht in [`basement/toolbox/projects/toolbox/README.md`](../basement/toolbox/projects/toolbox/README.md) beschreibt den minimalen Codex-Stack und offene Planungsfragen.
+- Wrapper [`basement/toolbox/bin/gcodex`](../basement/toolbox/bin/gcodex) bleibt der bevorzugte Einstiegspunkt; Shared Workspace unter `./shared` vorbereiten.
+- Kataloge, Inventare und Schemata bleiben Stub-Status, werden aber als Referenzrahmen für künftige Aufgaben gepflegt.
+
+## Cross-Layer Aufgaben für morgen
+1. **Codex/Ollama-Verbindung verifizieren**: Draft-Kommandos sichten, Smoke-Test-Skripte vorbereiten (ohne produktive Runs).
+2. **Wardrobe-Overlay-Matrix ausarbeiten**: Host-spezifische Unterschiede (macOS vs. Windows/NVIDIA) auflisten und Abgleich mit Shared-Workspace-Strategie durchführen.
+3. **Promotion-Gates konkretisieren**: Prüfpunkte aus `STATE_VERIFICATION.md` den Layern zuordnen und Entscheidungslogik skizzieren.
+4. **Toolbox-Dokumentation harmonisieren**: Doubletten im Compose-Draft bereinigen, Pending Tasks priorisieren, MCP-Gateway-Abhängigkeiten sammeln.
+5. **Telemetrie-Vorbereitung**: Entrance-Ordner um geplante Event-Flows ergänzen, ohne reale Daten einzubringen.
+
+## Referenzen
+- Architekturdiagramm und Layerbeschreibung: [`docs/architecture.md`](architecture.md)
+- Repository-Überblick: [`README.md`](../README.md)
+- Layer-spezifische Ordner: [`fundament/`](../fundament/), [`basement/`](../basement/), [`wardrobe/`](../wardrobe/), [`entrance/`](../entrance/), [`stable/`](../stable/)
+
+_Do not_ produktive Services, Secrets oder laufende Automationen einchecken; diese Revision bleibt ein reines Planungsartefakt.

--- a/entrance/README.md
+++ b/entrance/README.md
@@ -1,3 +1,4 @@
 Entrance bildet die Frühphase für Nutzerfeedback, Canaries und Telemetrie-Sammlungen.
 Hier werden Sandbox-Experimente vorbereitet, bevor sie Richtung Stable wandern.
+Aktueller Überblick: siehe ../docs/revision-2025-09-28.md (Abschnitt "Cross-Layer Aufgaben").
 Do not deploy produktive Features oder nicht abgesicherte Benutzerdaten in diesem Layer.

--- a/fundament/README.md
+++ b/fundament/README.md
@@ -1,5 +1,6 @@
 Fundament layer sammelt Basis-Konfigurationen und gemeinsame Vorbereitungen.
 Es dient als Ausgangspunkt für Netzwerke, Volumes und künftige Host-Prüfungen.
+Aktueller Überblick: siehe ../docs/revision-2025-09-28.md (Layer Snapshot "Fundament").
 Do not hinterlege laufzeitkritische Overrides oder produktive Zugangsdaten hier.
 
 ## Host-Baselines (Stand)

--- a/stable/README.md
+++ b/stable/README.md
@@ -1,3 +1,4 @@
 Stable repräsentiert die produktive Ebene mit gehärteten Diensten und Monitoring.
 Dieser Layer bündelt genehmigte Deployments sowie dauerhafte Observability-Pfade.
+Aktueller Überblick: siehe ../docs/revision-2025-09-28.md (Layer Snapshot "Stable").
 Do not ablegen ungeprüfte Features oder temporäre Testartefakte.

--- a/wardrobe/README.md
+++ b/wardrobe/README.md
@@ -1,3 +1,5 @@
 Wardrobe beherbergt Overlays und Verpackungen, die basement-Komponenten für Tests veredeln.
 Er kapselt CPU-, GPU- und CI-spezifische Einstellungen sowie Wrapper-Schnittstellen.
+Aktueller Überblick und Cross-Host-Planung: siehe ../docs/revision-2025-09-28.md.
+Fokus: Overlays als "Suit Switcher" für macOS- und Windows/NVIDIA-Hosts vorbereiten, Shared-Workspace beibehalten.
 Do not speichern endgültige Produktionskonfigurationen oder sicherheitsrelevante Geheimnisse hier.


### PR DESCRIPTION
## Summary
- add a dated repository revision document capturing today's inputs, layer status, and cross-layer tasks
- link every layer README plus the main architecture overview to the new revision snapshot for quick navigation
- tidy the toolbox project compose draft section while pointing contributors to the latest planning notes

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d8842b39a8832c85d0ea2c96d94c78