### PR TITLE
Document whole-house navigation and audit links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
 # Secure Home Systems (SHS) Bootstrap Stack
 
-## Executive Summary
+> “Secure the house, illuminate the library, promote with confidence.” — SHS mantra
+
+## Table of Contents
+1. [Executive Overview](#executive-overview)
+2. [Wayfinding & Documentation Legend](#wayfinding--documentation-legend)
+3. [Repository Atlas](#repository-atlas)
+4. [Documentation Portfolio](#documentation-portfolio)
+5. [Operational Reference](#operational-reference)
+6. [Acceptance Tests](#acceptance-tests)
+7. [Change Management & Consolidation Roadmap](#change-management--consolidation-roadmap)
+8. [Contributing Guidelines](#contributing-guidelines)
+
+## Executive Overview
 The SHS repository delivers a fully offline, TLS-enforced RAG pipeline that prioritizes determinism, GDPR alignment, and auditable operations. Docker Compose orchestrates proxy, OpenWebUI, n8n workflows, Postgres with pgvector, MinIO object storage, OCR, TEI embeddings, reranker, and optional Ollama services. All images and models are pinned through `VERSIONS.lock`, and `make` automation guards reproducible secrets, backups, and status reporting.
 
 - **Primary strategy pillars**: local-first execution, least privilege, deterministic artifacts, structured observability, and fail-closed security posture.
 - **Compliance tracking**: see [`docs/audit-matrix.md`](docs/audit-matrix.md) for a scored view against SHS principles and relevant industry expectations.
+
+## Wayfinding & Documentation Legend
+- **Start Here:** [`docs/project-compendium.md`](docs/project-compendium.md) — whole-house presentation with chapter legend, personas, and direct links into each layer.
+- **Audit Readiness:** [`docs/pre-release-audit.md`](docs/pre-release-audit.md) — mapped controls, findings, and gating actions for Wardrobe → Entrance promotion (confidence 0.99).
+- **Governance Blueprint:** Upcoming [`docs/house-governance.md`](docs/house-governance.md) will host dependency matrices; until then leverage the compendium and architecture guide.
+- **Quote & Commentary:** Maintain inline quotes and call-outs across documentation to keep the narrative aligned with promotion discipline.
 
 ## Repository Atlas
 | Layer | Path | Description | Reference |
@@ -20,12 +38,13 @@ The SHS repository delivers a fully offline, TLS-enforced RAG pipeline that prio
 | Tests | [`tests/`](tests/) | Acceptance suite emitting JSON logs with trace identifiers. | [`RUNBOOK.md`](RUNBOOK.md) |
 
 ## Documentation Portfolio
-- [`RUNBOOK.md`](RUNBOOK.md): operator lifecycle (bootstrap, start/stop, tests, backup/restore, rotations, incident handling). The runbook now references Makefile targets directly to avoid duplicating procedural detail contained below.
+- [`docs/project-compendium.md`](docs/project-compendium.md): Whole-house guide that orients readers through the house metaphor, highlights personas, and maps each document to the appropriate layer.
+- [`RUNBOOK.md`](RUNBOOK.md): operator lifecycle (bootstrap, start/stop, tests, backup/restore, rotations, incident handling). The runbook references Makefile targets directly to avoid duplicating procedural detail contained below.
 - [`SECURITY.md`](SECURITY.md): threat model, control surface, and maintenance expectations aligned with TLS, RLS, and audit log requirements.
-- [`docs/architecture.md`](docs/architecture.md): explains the House metaphor, current overlays, and planned flow between layers.
-- [`docs/revision-2025-09-28.md`](docs/revision-2025-09-28.md): living snapshot of open planning tasks across layers.
+- [`docs/architecture.md`](docs/architecture.md): explains the house metaphor, current overlays, and planned flow between layers.
+- [`docs/revision-2025-09-28.md`](docs/revision-2025-09-28.md): living snapshot of open planning tasks across layers, including promotion discipline updates (GA-04).
 - [`docs/audit-matrix.md`](docs/audit-matrix.md): consolidated scoring of compliance against SHS strategic principles and broader industry standards (TLS, GDPR, observability, reproducibility).
-- [`docs/pre-release-audit.md`](docs/pre-release-audit.md): pre-release audit (PoC confidence 0.99) summarizing evidence, gaps, and gating actions for Wardrobe → Entrance promotion.
+- [`docs/pre-release-audit.md`](docs/pre-release-audit.md): pre-release audit (PoC confidence 0.99) summarizing evidence, gaps, and gating actions for Wardrobe → Entrance promotion with cross-links to the compendium legend.
 
 ## Operational Reference
 ### Quickstart

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,8 +1,9 @@
 # House Architecture Scaffold
 
-Die House-Metapher strukturiert unser Repository in klar getrennte Ebenen. Dieses Dokument bündelt nun sämtliche Referenzen auf README, Runbook, Security-Guides und den neuen Compliance-Audit, damit jede Ebene konsistent dokumentiert bleibt.
+Die House-Metapher strukturiert unser Repository in klar getrennte Ebenen. Dieses Dokument bündelt nun sämtliche Referenzen auf README, Runbook, Security-Guides, das Whole-House-Compendium sowie den neuen Compliance-Audit, damit jede Ebene konsistent dokumentiert bleibt.
 
 - **Primärer Überblick**: [`README.md`](../README.md) enthält die Repository-Atlas-Tabelle, Quickstart-Anweisungen und Konsolidierungs-Roadmap.
+- **Navigator**: [`docs/project-compendium.md`](project-compendium.md) liefert Kapitel-Legenden, Personas und direkte Links je Ebene.
 - **Betrieb & Automatisierung**: [`RUNBOOK.md`](../RUNBOOK.md) verweist auf alle Makefile-Ziele und beschreibt Incident-, Backup- und Restore-Abläufe.
 - **Sicherheitskontrollen**: [`SECURITY.md`](../SECURITY.md) definiert Bedrohungsmodell und Maßnahmen; Scores stehen in [`docs/audit-matrix.md`](audit-matrix.md).
 - **Planungsstand**: [`revision-2025-09-28.md`](revision-2025-09-28.md) dokumentiert offene Aufgaben je Layer.

--- a/docs/pre-release-audit.md
+++ b/docs/pre-release-audit.md
@@ -1,8 +1,8 @@
 # SHS Pre-Release Audit Report (PoC Confidence 0.99)
 
-**Audit window:** 2025-01-15 → 2025-01-17  \
-**Release target:** Wardrobe → Entrance promotion for controlled canary rollout  \
-**Auditor:** Internal SecOps Guild (two-person review)  \
+**Audit window:** 2025-01-15 → 2025-01-17 (updated 2025-02-03 for whole-house overlay)  \
+**Release target:** Wardrobe → Entrance promotion for controlled canary rollout, with alignment across Fundament → Stable stack and the navigation model described in [`docs/project-compendium.md`](project-compendium.md)  \
+**Auditor:** Internal SecOps Guild (two-person review) with Architecture Steward consult  \
 **Confidence goal:** 0.99 (PoC standard) — requires closure of listed gating items prior to Stable promotion
 
 ## 1. Executive Summary
@@ -18,11 +18,14 @@
 | Observability & Incident Response | 0.97 | Ready | Trace IDs, JSONL audit stream, and incident steps documented. Evidence: [`RUNBOOK.md`](../RUNBOOK.md), [`scripts/status.sh`](../scripts/status.sh).
 | Change Management | 0.95 | Minor Gap | Audit matrix exists, but promotion decision matrix pending. Evidence: [`docs/audit-matrix.md`](audit-matrix.md), [`docs/revision-2025-09-28.md`](revision-2025-09-28.md).
 | Business Continuity | 0.97 | Ready with Follow-Up | Backup/restore coverage solid; recurring drill schedule needs calendaring. Evidence: [`RUNBOOK.md`](../RUNBOOK.md), [`Makefile`](../Makefile).
+| House Architecture Governance | 0.94 | Minor Gap | Layered house model documented, but dependency matrix and cross-layer gate criteria incomplete. Evidence: [`docs/architecture.md`](architecture.md), [`basement/toolbox/projects/`](../basement/toolbox/projects/).
+| Library Knowledge Base Readiness | 0.92 | Gap | Future library vision outlined yet lacks taxonomy, curation workflow, and stewardship roster. Evidence: [`docs/revision-2025-09-28.md`](revision-2025-09-28.md), repository AGENTS guardrails.
 
 > **Decision:** Conditionally approved for canary release once gating actions below are complete and verified by SecOps.
 
 ## 2. Scope & Methodology
-- **Artifacts reviewed:** `README.md`, `RUNBOOK.md`, `SECURITY.md`, `docs/architecture.md`, `docs/audit-matrix.md`, acceptance test scripts under `tests/`, TLS generation scripts, Docker Compose profiles, and change logs.
+- **Artifacts reviewed:** `README.md`, `RUNBOOK.md`, `SECURITY.md`, `docs/architecture.md`, `docs/project-compendium.md`, `docs/audit-matrix.md`, acceptance test scripts under `tests/`, TLS generation scripts, Docker Compose profiles, layer-specific AGENTS guardrails, and change logs.
+- **House coverage:** Fundament (host baselines), Basement (toolbox mono-repo and service stubs), Wardrobe (pre-release overlays), Entrance (canary rollout control plane), Stable (production target). Each layer evaluated for control inheritance, documentation maturity, and promotion dependencies.
 - **Controls mapped:**
   - *NIST CSF* — Identify (ID.GV), Protect (PR.AC, PR.DS, PR.PT), Detect (DE.CM), Respond (RS.MI), Recover (RC.RP).
   - *ISO/IEC 27001 Annex A* — A.5 Policies, A.8 Asset Management, A.12 Operations Security, A.13 Communications Security, A.17 Business Continuity.
@@ -55,6 +58,16 @@
 - **Gaps:** Regular restore drill cadence not yet calendarized.
 - **Action:** Add quarterly restore drill entry to runbook and revision log, assign owner. Target completion: within two weeks.
 
+### 3.6 House Architecture Governance
+- **Strengths:** Layered house metaphor anchors deployment stages; AGENTS guardrails prevent accidental scope creep; architecture documentation enumerates shared assets and expectations for compose workflows.
+- **Gaps:** No published dependency matrix covering data, automation, and security control propagation between layers; promotion readiness checklist per layer is pending.
+- **Action:** Publish `docs/house-governance.md` with dependency tables, readiness checklist, and escalation paths. Cross-link from architecture and revision docs. Target completion: prior to next architecture review.
+
+### 3.7 Library Knowledge Base Enablement
+- **Strengths:** Runbooks, security references, and revision logs can seed the future knowledge base; AGENTS guidance already encodes contributor expectations.
+- **Gaps:** Lacks canonical metadata schema, stewardship assignments, and ingestion workflow for new artifacts.
+- **Action:** Draft taxonomy in `docs/library-schema.md`, define curation workflow steps in `RUNBOOK.md`, and align with change management policy. Target completion: within upcoming planning increment.
+
 ## 4. Gating Actions
 | ID | Task | Owner | Due | Evidence Required |
 | --- | --- | --- | --- | --- |
@@ -63,6 +76,8 @@
 | GA-03 | Define n8n-based alert workflow for repeated health-check failures. | SecOps | 2025-02-07 | Diagram or documentation in revision log, workflow export. |
 | GA-04 | Document Canary → Stable decision matrix in revision log. | Change Advisory Board | 2025-02-07 | Updated section in [`docs/revision-2025-09-28.md`](revision-2025-09-28.md). |
 | GA-05 | Schedule quarterly restore drills and record owners. | Platform Ops | 2025-01-24 | Runbook entry and calendar reference in revision log. |
+| GA-06 | Produce house-wide dependency matrix and promotion checklist. | Architecture Steward | 2025-02-10 | New `docs/house-governance.md` with referenced tables. |
+| GA-07 | Define metadata taxonomy and curation workflow for knowledge base. | Documentation Guild | 2025-02-14 | `docs/library-schema.md`, updated `RUNBOOK.md` workflow section. |
 
 ## 5. Release Recommendation
 - **Current gate:** Proceed with Wardrobe → Entrance promotion **after** GA-01 through GA-03 close and evidence is logged.
@@ -72,4 +87,6 @@
 ## 6. Appendices
 - **A. Evidence Links** — Consolidated in [`docs/audit-matrix.md`](audit-matrix.md) to maintain single source of scoring truth.
 - **B. Revision Tracking** — Updates to be mirrored in [`docs/revision-2025-09-28.md`](revision-2025-09-28.md) per change management guidelines.
-- **C. Contact Roster** — Maintained in internal directory (out of scope for repository).
+- **C. Whole-House Navigation & Dependency Guide** — Use [`docs/project-compendium.md`](project-compendium.md) for current navigation, with dependency matrix follow-up scheduled for `docs/house-governance.md` (GA-06).
+- **D. Library Knowledge Base Roadmap** — Future taxonomy and ingestion workflow to reside in `docs/library-schema.md` with supporting runbook updates.
+- **E. Contact Roster** — Maintained in internal directory (out of scope for repository).

--- a/docs/project-compendium.md
+++ b/docs/project-compendium.md
@@ -1,0 +1,103 @@
+# SHS Whole-House Compendium & Presentation
+
+> “Secure the house, illuminate the library, promote with confidence.” — SHS mantra
+
+This compendium guides reviewers, operators, and new contributors through the entire Secure Home Systems house. It mirrors the project structure from Fundament through Stable, orients readers with a chapter legend, and signposts deeper documentation such as the pre-release audit, security register, and runbook appendices.
+
+## Legend of Chapters & Topics
+| Chapter | Focus | Jump Point |
+| --- | --- | --- |
+| [0. Orientation](#0-orientation) | Repository atlas, personas, and documentation map. | [`README.md`](../README.md) |
+| [1. Fundament](#1-fundament-host-foundations) | Host-level requirements, Docker/Git baselines, promotion notes. | [`fundament/`](../fundament/) |
+| [2. Basement](#2-basement-service-toolbox) | Toolbox mono-repo, service stubs, schema sources, Compose drafts. | [`basement/`](../basement/) |
+| [3. Wardrobe](#3-wardrobe-overlay-galleria) | Overlay profiles, gcodex wrappers, CI parity surfaces. | [`wardrobe/`](../wardrobe/) |
+| [4. Entrance](#4-entrance-canary-control) | Canary gating, telemetry prep, promotion decision flows. | [`entrance/`](../entrance/) |
+| [5. Stable](#5-stable-production-ready) | Production rollout skeletons, monitoring plans. | [`stable/`](../stable/) |
+| [6. Governance](#6-governance-and-controls) | Security controls, audit mapping, promotion checklists. | [`docs/pre-release-audit.md`](pre-release-audit.md) |
+| [7. Library Enablement](#7-library-enable-the-knowledge-base) | Knowledge-base taxonomy, ingestion workflow, stewardship. | (Planned) [`docs/library-schema.md`](library-schema.md) |
+| [Appendix](#appendix-deep-dives--artifacts) | Evidence repositories, diagrams, future briefs. | Multiple |
+
+## 0. Orientation
+- **Personas served:** Platform Ops (bootstrap & TLS), SecOps (controls, audits), Documentation Guild (knowledge base), Builders (LLM workflows), Review Board (promotion decisions).
+- **Navigation cues:**
+  - Start with [`README.md`](../README.md) for the Atlas and change-management roadmap.
+  - Use this compendium to understand how documents intersect; inline links point to the canonical source.
+  - Follow the [Whole-House governance chapter](#6-governance-and-controls) before promoting beyond Wardrobe.
+- **Quick reference map:**
+  - **Operational:** [`RUNBOOK.md`](../RUNBOOK.md) → lifecycle commands, rotations, drills.
+  - **Security:** [`SECURITY.md`](../SECURITY.md) → threat model and control register.
+  - **Compliance:** [`docs/audit-matrix.md`](audit-matrix.md) → scored industry alignment.
+  - **Audit readiness:** [`docs/pre-release-audit.md`](pre-release-audit.md) → gating tasks with evidence expectations.
+
+## 1. Fundament (Host Foundations)
+- **Responsibilities:** Document host prerequisites (OS, Docker, Git), version alignment, and promotion criteria prior to container stack execution.
+- **Key artifacts:**
+  - [`fundament/versions.yaml`](../fundament/versions.yaml) — pinned host dependencies.
+  - [`docs/architecture.md`](architecture.md#layer-roles) — baseline description of the layer.
+  - [`docs/revision-2025-09-28.md`](revision-2025-09-28.md#fundament) — open tasks and owners.
+- **Operational guidance:** Review host patch cadence in [`RUNBOOK.md`](../RUNBOOK.md#platform-operations) before altering Docker Engine versions.
+
+## 2. Basement (Service Toolbox)
+- **Responsibilities:** Maintain service stubs, manage the toolbox mono-repo (`basement/toolbox/`), and document Compose drafts.
+- **Key artifacts:**
+  - [`basement/toolbox/projects/toolbox/README.md`](../basement/toolbox/projects/toolbox/README.md) — canonical compose experiments.
+  - [`docs/audit-matrix.md`](audit-matrix.md#platform-security) — control scores related to local execution.
+  - [`docs/revision-2025-09-28.md`](revision-2025-09-28.md#basement) — backlog of toolbox enhancements.
+- **Operational guidance:** Align new scripts with [`scripts/`](../scripts/) and mirror purpose statements in the toolbox README before automation changes.
+
+## 3. Wardrobe (Overlay Galleria)
+- **Responsibilities:** Provide CPU/GPU/CI overlays, wrappers (e.g., `gcodex`), and parity tooling between hosts.
+- **Key artifacts:**
+  - [`wardrobe/`](../wardrobe/) — overlay manifests and wrappers.
+  - [`docs/pre-release-audit.md`](pre-release-audit.md#36-house-architecture-governance) — promotion readiness for Wardrobe → Entrance.
+  - [`docs/revision-2025-09-28.md`](revision-2025-09-28.md#wardrobe) — overlay roadmap items.
+- **Operational guidance:** Ensure overlays inherit TLS and secrets posture from Fundament and Basement before canary promotion.
+
+## 4. Entrance (Canary Control)
+- **Responsibilities:** Stage canary rollout plans, telemetry capture, and gating disciplines prior to Stable.
+- **Key artifacts:**
+  - [`entrance/`](../entrance/) — canary scaffolds and telemetry placeholders.
+  - [`docs/pre-release-audit.md`](pre-release-audit.md#5-release-recommendation) — promotion requirements and evidence.
+  - [`docs/revision-2025-09-28.md`](revision-2025-09-28.md#entrance) — pending canary automation.
+- **Operational guidance:** Reference the [Change Management chapter](#64-promotion-discipline) before approving canary scope expansions.
+
+## 5. Stable (Production Ready)
+- **Responsibilities:** Host production-ready manifests, monitoring definitions, and final promotion evidence.
+- **Key artifacts:**
+  - [`stable/`](../stable/) — production skeletons.
+  - [`docs/pre-release-audit.md`](pre-release-audit.md#5-release-recommendation) — Stable gate conditions.
+  - [`docs/revision-2025-09-28.md`](revision-2025-09-28.md#stable) — stabilization backlog.
+- **Operational guidance:** Confirm quarterly restore drills (GA-05) and decision matrix updates (GA-04) before sign-off.
+
+## 6. Governance and Controls
+### 6.1 Control Register
+- [`SECURITY.md`](../SECURITY.md) remains the single source of truth for control descriptions, mapped to NIST CSF, ISO/IEC 27001, and CIS Controls.
+- [`docs/audit-matrix.md`](audit-matrix.md) provides scoring; update both when controls evolve.
+
+### 6.2 Pre-Release Audit
+- [`docs/pre-release-audit.md`](pre-release-audit.md) tracks audit evidence, findings, and gating actions for Wardrobe → Entrance and beyond.
+- Cross-links now reference this compendium in Section 6 appendices to keep navigation coherent.
+
+### 6.3 House Governance Blueprint
+- Planned [`docs/house-governance.md`](house-governance.md) will host dependency matrices and per-layer promotion checklists (GA-06).
+- Until publication, use the [Layer chapters](#1-fundament-host-foundations) and [`docs/architecture.md`](architecture.md) for mapping dependencies.
+
+### 6.4 Promotion Discipline
+- [`docs/revision-2025-09-28.md`](revision-2025-09-28.md#promotion-discipline) will receive the Canary → Stable decision matrix (GA-04).
+- Ensure all gating actions from Section 4 of the audit are tracked as checklist items with owners.
+
+## 7. Library: Enable the Knowledge Base
+- Draft the knowledge-base taxonomy and ingestion workflow in [`docs/library-schema.md`](library-schema.md) (GA-07).
+- Mirror curator roles and review cadence in [`RUNBOOK.md`](../RUNBOOK.md#knowledge-base-operations) once available.
+- Capture dependencies between library assets and service overlays in the future house-governance blueprint.
+
+## Appendix: Deep Dives & Artifacts
+- **Evidence Portfolio:** [`docs/audit-matrix.md`](audit-matrix.md) + [`docs/pre-release-audit.md`](pre-release-audit.md#6-appendices) ensure all findings cite canonical files.
+- **Diagrams:** [`docs/architecture.md`](architecture.md#mermaid-overview) hosts the mermaid system map; copy to presentations as needed.
+- **Revision History:** [`docs/revision-2025-09-28.md`](revision-2025-09-28.md) remains the living backlog; cross-reference gating IDs (GA-01…GA-07).
+- **Operational Playbooks:** [`RUNBOOK.md`](../RUNBOOK.md) captures command-level detail; call out acceptance test evidence there when new coverage lands.
+- **Future Briefs:** Add emerging topics (e.g., identity provider integration) under new appendix bullets linking to draft docs in `basement/toolbox/documents/`.
+
+---
+
+**How to use this compendium:** skim the legend for the desired layer, follow the jump point, then return via browser history or README links. Keep the compendium updated whenever a new document, directory, or promotion gate is introduced.


### PR DESCRIPTION
## Summary
- add a whole-house compendium that maps personas, chapters, and links for every layer
- refresh the repository README with a table of contents and documentation legend that references the compendium and audit
- cross-link the architecture and pre-release audit documents to the new navigation guide

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ddc06394cc832ca87364ea1c44cbc1