### PR TITLE
Add TLS fingerprint verification to status workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,11 @@ SHS_UID=1000
 SHS_GID=1000
 SHS_PROXY_PORT=8443
 
+# TLS fingerprint verification (optional)
+# Provide either the expected SHA-256 fingerprint string or a file path containing it.
+# SHS_TLS_LEAF_FINGERPRINT_SHA256=AA:BB:CC:DD:...
+# SHS_TLS_LEAF_FINGERPRINT_FILE=secrets/tls/leaf.sha256
+
 # Database
 POSTGRES_IMAGE=postgres:15.6
 POSTGRES_DB=shs

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -15,12 +15,20 @@ This runbook is the operational companion to the repository atlas in [`README.md
     - copy `.env.example` into `.env.local` when absent.
 3. Validate `VERSIONS.lock` contains the intended image tags, digests, and model metadata referenced by `compose.yaml` and service configs.
 
+## TLS Fingerprint Verification
+1. After generating certificates, record the expected SHA-256 fingerprint for the leaf certificate:
+    - `openssl x509 -in secrets/tls/leaf.pem -noout -fingerprint -sha256 > secrets/tls/leaf.sha256`
+2. Provide the baseline to `scripts/status.sh` by either:
+    - setting `SHS_TLS_LEAF_FINGERPRINT_SHA256` in `.env.local`, or
+    - setting `SHS_TLS_LEAF_FINGERPRINT_FILE` to the fingerprint file path (defaults to `secrets/tls/leaf.sha256`).
+3. Run `make status` to confirm the observed fingerprint matches the expected baseline before promoting artifacts.
+
 ## Lifecycle Commands
 | Action | Command | Notes |
 | --- | --- | --- |
 | Start services | `make up` | Defaults to the `minimal` profile; pass `PROFILE=gpu` to target the GPU overlay. |
 | Stop services | `make down` | Leaves persistent volumes intact; use `docker compose down -v` manually for destructive cleanup. |
-| Status summary | `make status` | Calls `scripts/status.sh` to report HTTPS endpoints, enabled profiles, and health probe results. |
+| Status summary | `make status` | Calls `scripts/status.sh` to report HTTPS endpoints, enabled profiles, health probes, and TLS fingerprint validation. |
 | Acceptance suite | `make test` | Runs all scripts under `tests/acceptance/` with trace-aware JSON logging. |
 | Rotate CA | `make ca.rotate` | Forces deterministic regeneration of CA/leaf materials; rerun `make up` afterwards. |
 | Backup | `make backup` | Produces `backups/shs-<timestamp>.tar.zst` containing TLS, logs, versions, and a Postgres dump. |

--- a/docs/pre-release-audit.md
+++ b/docs/pre-release-audit.md
@@ -32,7 +32,7 @@ The audit team executed the review using dual-control validation and evidence tr
 | NIST CSF PR.AC, PR.DS | TLS-only ingress, RLS enforcement, credential segregation | Implemented | Validated via `make bootstrap` artefacts and Postgres policies. |
 | NIST CSF DE.CM, RS.MI | Health probes, JSONL traces, incident workflow | Implemented with enhancement planned | Alert automation pending (GA-03). |
 | ISO/IEC 27001 A.12, A.17 | Deterministic builds, backup and recovery runbooks | Implemented | Quarterly drill schedule outstanding (GA-05). |
-| CIS Controls 4, 8, 11 | Hardened compose baselines, audit log management, restore coverage | Implemented with monitoring gap | Certificate fingerprint validation pending (GA-01). |
+| CIS Controls 4, 8, 11 | Hardened compose baselines, audit log management, restore coverage | Implemented with monitoring gap | Certificate fingerprint validation scripted; awaiting CA baseline capture (GA-01). |
 | GDPR Articles 5, 17 | Data minimisation, deletion readiness | Partially implemented | Evidence required for executed deletion playbook (GA-02). |
 
 > **Decision:** Conditionally approved for canary release once gating actions below are complete and verified by SecOps.
@@ -50,7 +50,7 @@ The audit team executed the review using dual-control validation and evidence tr
 ## 3. Residual Risk Register
 | ID | Domain | Severity | Description | Mitigation Path | Target Residual |
 | --- | --- | --- | --- | --- | --- |
-| RR-01 | Platform Security | Medium | Lack of automated certificate fingerprint validation could allow unnoticed drift. | Implement GA-01 and embed fingerprint baseline in `make status`. | Low |
+| RR-01 | Platform Security | Medium | Automated fingerprint verification available once baseline is supplied. | Capture CA fingerprint baseline and log `make status` validation output. | Low |
 | RR-02 | Data Protection | Medium | Deletion workflow evidence absent; risk of incomplete GDPR fulfilment. | Execute GA-02 with acceptance coverage and documented appendix. | Low |
 | RR-03 | Change Management | Medium | Promotion decision matrix missing, reducing governance transparency. | Complete GA-04 with CAB approval and cross-links. | Low |
 | RR-04 | Business Continuity | Medium | Restore drills not scheduled; risk of skill atrophy. | Calendarise per GA-05 and log outcomes. | Low |
@@ -59,8 +59,8 @@ The audit team executed the review using dual-control validation and evidence tr
 ## 4. Findings & Recommendations
 ### 4.1 Platform Security
 - **Strengths:** Automated CA generation with deterministic output, strict TLS-only proxy enforcing mTLS upstream, fail-closed service start via health checks.
-- **Gaps:** No automated certificate integrity check wired into `make status`.
-- **Action:** Extend status script to validate cert fingerprints (mapped to CIS Control 4.1). Target completion: prior to Entrance promotion.
+- **Gaps:** Baseline certificate fingerprint still to be captured with the updated status workflow.
+- **Action:** Use the updated status script to validate cert fingerprints and capture evidence before Entrance promotion.
 
 ### 4.2 Data Protection & Privacy
 - **Strengths:** Row-level security policies, hashed identifiers, structured deletion workflows described in runbook, n8n flows aligning with GDPR minimization principles.
@@ -95,7 +95,7 @@ The audit team executed the review using dual-control validation and evidence tr
 ## 5. Gating Actions
 | ID | Task | Owner | Due | Status | Evidence Required |
 | --- | --- | --- | --- | --- | --- |
-| GA-01 | Integrate certificate fingerprint verification into `make status`. | Platform Ops | 2025-01-24 | Open | Updated `scripts/status.sh`, command output screenshot/log. |
+| GA-01 | Integrate certificate fingerprint verification into `make status`. | Platform Ops | 2025-01-24 | Ready for validation | Updated `scripts/status.sh`, runbook fingerprint procedure, command output screenshot/log. |
 | GA-02 | Publish GDPR deletion playbook appendix and add automated deletion test. | Data Steward | 2025-01-31 | In Progress | `RUNBOOK.md` appendix, new acceptance test log. |
 | GA-03 | Define n8n-based alert workflow for repeated health-check failures. | SecOps | 2025-02-07 | Planned | Diagram or documentation in revision log, workflow export. |
 | GA-04 | Document Canary → Stable decision matrix in revision log. | Change Advisory Board | 2025-02-07 | Planned | Updated section in [`docs/revision-2025-09-28.md`](revision-2025-09-28.md). |

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -6,6 +6,54 @@ ENV_FILE="${ROOT}/.env.local"
 VERSIONS="${ROOT}/VERSIONS.lock"
 TLS_DIR="${ROOT}/secrets/tls"
 
+normalize_fingerprint() {
+  local value="${1:-}"
+  value="$(printf '%s' "${value}" | tr -d '[:space:]:-' | tr '[:lower:]' '[:upper:]')"
+  printf '%s' "${value}"
+}
+
+format_fingerprint_display() {
+  local normalized
+  normalized="$(normalize_fingerprint "${1:-}")"
+  if [[ -z "${normalized}" ]]; then
+    return 1
+  fi
+
+  local length="${#normalized}"
+  local result=""
+  local i=0
+  while [[ "${i}" -lt "${length}" ]]; do
+    local chunk="${normalized:${i}:2}"
+    if [[ -n "${chunk}" ]]; then
+      if [[ -n "${result}" ]]; then
+        result+=":${chunk}"
+      else
+        result="${chunk}"
+      fi
+    fi
+    i=$((i + 2))
+  done
+
+  printf '%s' "${result}"
+}
+
+read_expected_fingerprint() {
+  local inline_value="${1:-}"
+  local file_path="${2:-}"
+
+  if [[ -n "${inline_value}" ]]; then
+    printf '%s' "${inline_value}"
+    return 0
+  fi
+
+  if [[ -n "${file_path}" && -f "${file_path}" ]]; then
+    tr -d '\r\n' < "${file_path}"
+    return 0
+  fi
+
+  return 1
+}
+
 if [[ -f "${ENV_FILE}" ]]; then
   set -a
   source "${ENV_FILE}"
@@ -43,3 +91,55 @@ echo "Health probes  :"
 echo "  - ${BASE_URL}/healthz"
 echo "  - ${BASE_URL}/readyz"
 echo "  - ${BASE_URL}/api/status"
+echo "TLS fingerprints:"
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "  - openssl not available; skipping fingerprint verification"
+elif [[ ! -d "${TLS_DIR}" ]]; then
+  echo "  - TLS directory missing (${TLS_DIR}); run make bootstrap"
+else
+  LEAF_CERT="${TLS_DIR}/leaf.pem"
+  EXPECTED_FILE="${SHS_TLS_LEAF_FINGERPRINT_FILE:-${TLS_DIR}/leaf.sha256}"
+
+  if [[ ! -f "${LEAF_CERT}" ]]; then
+    echo "  - Leaf certificate missing (${LEAF_CERT}); run scripts/tls/gen_local_ca.sh"
+  elif ACTUAL_RAW="$(openssl x509 -in "${LEAF_CERT}" -noout -fingerprint -sha256 2>/dev/null)"; then
+    ACTUAL_VALUE="${ACTUAL_RAW#*=}"
+    ACTUAL_NORMALIZED="$(normalize_fingerprint "${ACTUAL_VALUE}")"
+    if ! ACTUAL_DISPLAY="$(format_fingerprint_display "${ACTUAL_NORMALIZED}")"; then
+      ACTUAL_DISPLAY="$(printf '%s' "${ACTUAL_VALUE}" | tr -d '[:space:]')"
+    fi
+
+    EXPECTED_RAW=""
+    EXPECTED_NORMALIZED=""
+    EXPECTED_DISPLAY=""
+    if EXPECTED_RAW="$(read_expected_fingerprint "${SHS_TLS_LEAF_FINGERPRINT_SHA256:-}" "${EXPECTED_FILE}" 2>/dev/null)"; then
+      EXPECTED_NORMALIZED="$(normalize_fingerprint "${EXPECTED_RAW}")"
+      if [[ -n "${EXPECTED_NORMALIZED}" ]]; then
+        if ! EXPECTED_DISPLAY="$(format_fingerprint_display "${EXPECTED_NORMALIZED}")"; then
+          EXPECTED_DISPLAY="$(printf '%s' "${EXPECTED_RAW}" | tr -d '[:space:]')"
+        fi
+      fi
+    fi
+
+    if [[ -n "${EXPECTED_NORMALIZED}" ]]; then
+      if [[ "${ACTUAL_NORMALIZED}" == "${EXPECTED_NORMALIZED}" ]]; then
+        echo "  - Leaf certificate fingerprint matches baseline (${ACTUAL_DISPLAY})"
+      else
+        echo "  - Leaf certificate fingerprint mismatch"
+        if [[ -n "${EXPECTED_DISPLAY}" ]]; then
+          echo "    expected: ${EXPECTED_DISPLAY}"
+        fi
+        echo "    observed: ${ACTUAL_DISPLAY}"
+      fi
+    else
+      echo "  - Baseline fingerprint not provided"
+      if [[ -n "${ACTUAL_DISPLAY}" ]]; then
+        echo "    observed: ${ACTUAL_DISPLAY}"
+      fi
+      echo "    configure SHS_TLS_LEAF_FINGERPRINT_SHA256 or SHS_TLS_LEAF_FINGERPRINT_FILE"
+    fi
+  else
+    echo "  - Unable to read fingerprint from ${LEAF_CERT}"
+  fi
+fi


### PR DESCRIPTION
## Summary
- add helper routines to `scripts/status.sh` to read the expected certificate fingerprint and compare it with the observed TLS leaf certificate
- document how to record the fingerprint baseline in the runbook and environment template so operators can supply values for the new check
- refresh the audit report to reflect that GA-01 is ready for validation once the CA fingerprint baseline is captured

## Testing
- ./scripts/status.sh

------
https://chatgpt.com/codex/tasks/task_e_68ddc7d82c40832ca9e75ed1583bdc93